### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+#Phillip IDE files
+.idea/


### PR DESCRIPTION
usuwa jetbeansowe pliki z kontroli wersji